### PR TITLE
Remove `ColumnsAir`

### DIFF
--- a/crates/cpu-backend/benches/keccakf.rs
+++ b/crates/cpu-backend/benches/keccakf.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use openvm_stark_backend::{
     prover::{AirProvingContext, ColMajorMatrix, DeviceDataTransporter, ProvingContext},
-    ColumnsAir, PartitionedBaseAir, StarkEngine, SystemParams,
+    PartitionedBaseAir, StarkEngine, SystemParams,
 };
 use openvm_stark_sdk::config::{
     app_params_with_100_bits_security,
@@ -34,7 +34,6 @@ impl<F> BaseAir<F> for TestAir {
     }
 }
 impl<F: Field> BaseAirWithPublicValues<F> for TestAir {}
-impl<F: Field> ColumnsAir<F> for TestAir {}
 impl<F: Field> PartitionedBaseAir<F> for TestAir {}
 
 impl<AB: AirBuilder> Air<AB> for TestAir {

--- a/crates/cpu-backend/examples/keccakf.rs
+++ b/crates/cpu-backend/examples/keccakf.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use eyre::eyre;
 use openvm_stark_backend::{
     prover::{AirProvingContext, DeviceDataTransporter, ProvingContext},
-    ColumnsAir, PartitionedBaseAir, StarkEngine,
+    PartitionedBaseAir, StarkEngine,
 };
 use openvm_stark_sdk::config::{
     app_params_with_100_bits_security, baby_bear_poseidon2::BabyBearPoseidon2CpuEngine,
@@ -30,7 +30,6 @@ impl<F> BaseAir<F> for TestAir {
     }
 }
 impl<F: Field> BaseAirWithPublicValues<F> for TestAir {}
-impl<F: Field> ColumnsAir<F> for TestAir {}
 impl<F: Field> PartitionedBaseAir<F> for TestAir {}
 
 impl<AB: AirBuilder> Air<AB> for TestAir {

--- a/crates/cuda-backend/examples/keccakf.rs
+++ b/crates/cuda-backend/examples/keccakf.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::Field,
     prover::{AirProvingContext, ColMajorMatrix, DeviceDataTransporter, ProvingContext},
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkEngine, SystemParams,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkEngine, SystemParams,
 };
 use openvm_stark_sdk::{
     config::{
@@ -34,7 +34,6 @@ impl<F> BaseAir<F> for TestAir {
     }
 }
 impl<F: Field> BaseAirWithPublicValues<F> for TestAir {}
-impl<F: Field> ColumnsAir<F> for TestAir {}
 impl<F: Field> PartitionedBaseAir<F> for TestAir {}
 
 impl<AB: AirBuilder> Air<AB> for TestAir {

--- a/crates/stark-backend/src/any_air.rs
+++ b/crates/stark-backend/src/any_air.rs
@@ -14,15 +14,6 @@ use crate::{
     config::StarkProtocolConfig,
 };
 
-/// If available, returns the names of columns used in this AIR.
-pub trait ColumnsAir<F>: BaseAir<F> {
-    /// If the result is `Some(names)`, `names.len() == air.width()` should always
-    /// be true.
-    fn columns(&self) -> Option<Vec<String>> {
-        None
-    }
-}
-
 /// An AIR with 1 or more main trace partitions.
 pub trait PartitionedBaseAir<F>: BaseAir<F> {
     /// By default, an AIR has no cached main trace.
@@ -47,7 +38,6 @@ Air<SymbolicRapBuilder<SC::F>> // for keygen to extract fixed data about the RAP
     + for<'a> Air<DebugConstraintBuilder<'a, SC>> // for debugging
     + BaseAirWithPublicValues<SC::F>
     + PartitionedBaseAir<SC::F>
-    + ColumnsAir<SC::F>
     + Send + Sync
 {
     fn as_any(&self) -> &dyn Any;
@@ -62,7 +52,6 @@ where
         + for<'a> Air<DebugConstraintBuilder<'a, SC>>
         + BaseAirWithPublicValues<SC::F>
         + PartitionedBaseAir<SC::F>
-        + ColumnsAir<SC::F>
         + Send
         + Sync
         + 'static,

--- a/crates/stark-backend/src/test_utils/dummy_airs/fib_air/air.rs
+++ b/crates/stark-backend/src/test_utils/dummy_airs/fib_air/air.rs
@@ -4,12 +4,11 @@ use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, BaseAirWithPu
 use p3_matrix::Matrix;
 
 use super::columns::{FibonacciCols, NUM_FIBONACCI_COLS};
-use crate::{ColumnsAir, PartitionedBaseAir};
+use crate::PartitionedBaseAir;
 
 #[derive(Clone, Copy)]
 pub struct FibonacciAir;
 
-impl<F> ColumnsAir<F> for FibonacciAir {}
 impl<F> PartitionedBaseAir<F> for FibonacciAir {}
 impl<F> BaseAir<F> for FibonacciAir {
     fn width(&self) -> usize {

--- a/crates/stark-backend/src/test_utils/dummy_airs/fib_selector_air/air.rs
+++ b/crates/stark-backend/src/test_utils/dummy_airs/fib_selector_air/air.rs
@@ -10,7 +10,7 @@ use super::columns::FibonacciSelectorCols;
 use crate::{
     interaction::{InteractionBuilder, LookupBus},
     test_utils::dummy_airs::fib_air::columns::{FibonacciCols, NUM_FIBONACCI_COLS},
-    ColumnsAir, PartitionedBaseAir,
+    PartitionedBaseAir,
 };
 
 pub struct FibonacciSelectorAir {
@@ -31,7 +31,6 @@ impl FibonacciSelectorAir {
     }
 }
 
-impl<F: Field> ColumnsAir<F> for FibonacciSelectorAir {}
 impl<F: Field> PartitionedBaseAir<F> for FibonacciSelectorAir {}
 impl<F: Field> BaseAir<F> for FibonacciSelectorAir {
     fn width(&self) -> usize {

--- a/crates/stark-backend/src/test_utils/dummy_airs/interaction/dummy_interaction_air.rs
+++ b/crates/stark-backend/src/test_utils/dummy_airs/interaction/dummy_interaction_air.rs
@@ -17,7 +17,7 @@ use crate::{
         stacked_pcs::stacked_commit, AirProvingContext, ColMajorMatrix, CommittedTraceData,
         CpuColMajorBackend,
     },
-    AirRef, ColumnsAir, PartitionedBaseAir, StarkProtocolConfig,
+    AirRef, PartitionedBaseAir, StarkProtocolConfig,
 };
 
 pub struct DummyInteractionCols;
@@ -65,7 +65,6 @@ impl DummyInteractionAir {
 }
 
 impl<F> BaseAirWithPublicValues<F> for DummyInteractionAir {}
-impl<F> ColumnsAir<F> for DummyInteractionAir {}
 impl<F> PartitionedBaseAir<F> for DummyInteractionAir {
     fn cached_main_widths(&self) -> Vec<usize> {
         if self.partition {

--- a/crates/stark-backend/src/test_utils/dummy_airs/interaction/self_interaction_air.rs
+++ b/crates/stark-backend/src/test_utils/dummy_airs/interaction/self_interaction_air.rs
@@ -6,7 +6,7 @@ use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use crate::{
     interaction::{BusIndex, InteractionBuilder},
     prover::{AirProvingContext, ColMajorMatrix, CpuColMajorBackend},
-    ColumnsAir, PartitionedBaseAir, StarkProtocolConfig,
+    PartitionedBaseAir, StarkProtocolConfig,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -21,7 +21,6 @@ impl<F> BaseAir<F> for SelfInteractionAir {
     }
 }
 impl<F> BaseAirWithPublicValues<F> for SelfInteractionAir {}
-impl<F> ColumnsAir<F> for SelfInteractionAir {}
 impl<F> PartitionedBaseAir<F> for SelfInteractionAir {}
 
 impl<AB: AirBuilder + InteractionBuilder> Air<AB> for SelfInteractionAir {

--- a/crates/stark-backend/src/test_utils/dummy_airs/preprocessed_cached_air/air.rs
+++ b/crates/stark-backend/src/test_utils/dummy_airs/preprocessed_cached_air/air.rs
@@ -2,7 +2,7 @@ use p3_air::{Air, AirBuilder, BaseAir, BaseAirWithPublicValues, PairBuilder};
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
 
-use crate::{air_builders::PartitionedAirBuilder, ColumnsAir, PartitionedBaseAir};
+use crate::{air_builders::PartitionedAirBuilder, PartitionedBaseAir};
 
 #[derive(Clone)]
 pub struct PreprocessedCachedAir {
@@ -20,7 +20,6 @@ impl PreprocessedCachedAir {
     }
 }
 
-impl<F: Field> ColumnsAir<F> for PreprocessedCachedAir {}
 impl<F: Field> PartitionedBaseAir<F> for PreprocessedCachedAir {
     fn cached_main_widths(&self) -> Vec<usize> {
         vec![1; self.num_cached_parts]

--- a/crates/stark-backend/tests/partitioned_sum_air.rs
+++ b/crates/stark-backend/tests/partitioned_sum_air.rs
@@ -15,7 +15,7 @@ use openvm_stark_backend::{
     air_builders::PartitionedAirBuilder,
     prover::{stacked_pcs::stacked_commit, AirProvingContext, ColMajorMatrix, CommittedTraceData},
     utils::disable_debug_builder,
-    ColumnsAir, PartitionedBaseAir, StarkEngine, StarkProtocolConfig,
+    PartitionedBaseAir, StarkEngine, StarkProtocolConfig,
 };
 use openvm_stark_sdk::{config::baby_bear_poseidon2::*, utils::setup_tracing};
 use p3_air::{Air, BaseAir, BaseAirWithPublicValues};
@@ -28,7 +28,6 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 struct SumAir(usize);
 
 impl<F> BaseAirWithPublicValues<F> for SumAir {}
-impl<F> ColumnsAir<F> for SumAir {}
 impl<F> PartitionedBaseAir<F> for SumAir {
     fn cached_main_widths(&self) -> Vec<usize> {
         vec![self.0]

--- a/crates/stark-sdk/examples/keccakf.rs
+++ b/crates/stark-sdk/examples/keccakf.rs
@@ -10,7 +10,7 @@ use openvm_stark_sdk::{
         p3_air::{Air, AirBuilder, BaseAir, BaseAirWithPublicValues},
         p3_field::Field,
         prover::{AirProvingContext, DeviceDataTransporter, ProvingContext},
-        ColumnsAir, PartitionedBaseAir, StarkEngine,
+        PartitionedBaseAir, StarkEngine,
     },
 };
 use p3_keccak_air::KeccakAir;
@@ -28,7 +28,6 @@ impl<F> BaseAir<F> for TestAir {
     }
 }
 impl<F: Field> BaseAirWithPublicValues<F> for TestAir {}
-impl<F: Field> ColumnsAir<F> for TestAir {}
 impl<F: Field> PartitionedBaseAir<F> for TestAir {}
 
 impl<AB: AirBuilder> Air<AB> for TestAir {


### PR DESCRIPTION
Reduces the [diff to upstream](https://github.com/openvm-org/stark-backend/compare/v2.0.0-beta.2...powdr-labs:stark-backend:v2-powdr-beta.2-remove-columns-air#diff-d76a887b1efdb4a6b77ca9d03cfb0ba301c20d4f2d389e119211cf9f208a6ecaR35).